### PR TITLE
Add control for secondary division position in layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # MangaPanelizer
 
-MangaPanelizer es un paquete de nodos personalizados para ComfyUI enfocado en diseÒar p·ginas de manga y cÛmic listas para imprimir. El nodo principal **CR_ComicPanelTemplates** genera composiciones limpias a partir de plantillas predefinidas o cadenas personalizadas y puede rellenar los paneles con tus im·genes renderizadas.
+- Control total de divisiones rectas con `Division Position` (para filas/columnas dobles) y `Secondary Division Position` (para subdivisiones internas como H12 y V12).
+- `division_position`: ajusta la divisin principal cuando hay dos filas/columnas.
+- `secondary_division_position`: desplaza la divisin interna en layouts con subpaneles (por ejemplo, H12 y V12).
+MangaPanelizer es un paquete de nodos personalizados para ComfyUI enfocado en dise√±ar p√°ginas de manga y c√≥mic listas para imprimir. El nodo principal **CR_ComicPanelTemplates** genera composiciones limpias a partir de plantillas predefinidas o cadenas personalizadas y puede rellenar los paneles con tus im√°genes renderizadas.
 
-## CaracterÌsticas clave
+## Caracter√≠sticas clave
 - Plantillas G/H/V para cuadr?culas, filas y columnas con ?ngulos controlados ?nicamente mediante `first_division_angle` y `second_division_angle`.
-- Controles separados para m·rgenes externos (`border_thickness`) y separaciÛn interna entre paneles (`internal_padding`).
+- Controles separados para m√°rgenes externos (`border_thickness`) y separaci√≥n interna entre paneles (`internal_padding`).
 - Desplazamientos ajustables para diagonales (`first_division_angle`, `diagonal_slant_offset (second_division_angle)`) que permiten mover el punto de encuentro en ambos ejes.
-- Trazos uniformes con antialiasing para bordes y diagonales sin ìsierraî.
-- Colores personalizables para contorno, panel y fondo; compatibilidad con lotes de im·genes.
-- Lectura izquierda?derecha o derecha?izquierda con un solo cambio de par·metro.
+- Trazos uniformes con antialiasing para bordes y diagonales sin ‚Äúsierra‚Äù.
+- Colores personalizables para contorno, panel y fondo; compatibilidad con lotes de im√°genes.
+- Lectura izquierda?derecha o derecha?izquierda con un solo cambio de par√°metro.
 
-## InstalaciÛn
+## Instalaci√≥n
 1. Entra en tu carpeta `ComfyUI/custom_nodes`.
 2. Clona el repositorio o copia esta carpeta: `git clone https://github.com/your-user/MangaPanelizer.git`.
-3. Reinicia ComfyUI. Encontrar·s el nodo bajo **MangaPanelizer / Templates**.
+3. Reinicia ComfyUI. Encontrar√°s el nodo bajo **MangaPanelizer / Templates**.
 
 ## Nodo disponible
 ### CR_ComicPanelTemplates
-Genera una p·gina completa y devuelve:
+Genera una p√°gina completa y devuelve:
 - `image`: tensor de imagen listo para ComfyUI.
-- `show_help`: texto con recordatorios r·pidos del uso.
+- `show_help`: texto con recordatorios r√°pidos del uso.
 
 #### Entradas obligatorias
-- `page_width`, `page_height`: tamaÒo del lienzo interior (sin contar `border_thickness`).
+- `page_width`, `page_height`: tama√±o del lienzo interior (sin contar `border_thickness`).
 - `template`: plantilla predefinida (ver lista). El valor `custom` habilita la cadena personalizada.
-- `reading_direction`: `left to right` o `right to left` (invierte horizontalmente la p·gina al final).
-- `border_thickness`: margen exterior que rodea toda la composiciÛn.
+- `reading_direction`: `left to right` o `right to left` (invierte horizontalmente la p√°gina al final).
+- `border_thickness`: margen exterior que rodea toda la composici√≥n.
 - `outline_thickness`: grosor del trazo de paneles.
 - `outline_color`, `panel_color`, `background_color`: paleta predefinida compartida.
-- `custom_panel_layout`: cadena usada cuando `template = custom` (se ignora en otros casos, pero siempre est· visible para que puedas editarla r·pido).
-- `internal_padding`: separaciÛn entre paneles sucesivos.
-- `first_division_angle`: desplaza la uniÛn vertical de diagonales (afecta `H` y columnas dentro de `V`).
-- `diagonal_slant_offset (second_division_angle)`: desplaza la uniÛn horizontal de diagonales (afecta `H` y `V`).
+- `custom_panel_layout`: cadena usada cuando `template = custom` (se ignora en otros casos, pero siempre est√° visible para que puedas editarla r√°pido).
+- `internal_padding`: separaci√≥n entre paneles sucesivos.
+- `first_division_angle`: desplaza la uni√≥n vertical de diagonales (afecta `H` y columnas dentro de `V`).
+- `diagonal_slant_offset (second_division_angle)`: desplaza la uni√≥n horizontal de diagonales (afecta `H` y `V`).
 
 #### Entradas opcionales
 - `images`: lote de tensores. Cada panel recibe la siguiente imagen disponible; si faltan, se rellenan con el color del panel.
@@ -57,19 +60,19 @@ Las cadenas solo describen la estructura: letras `H` o `V` seguidas de d?gitos. 
 - `V32` - Tres columnas principales y una columna con dos paneles apilados.
 
 ## Consejos de uso
-- **Separaciones**: `internal_padding` aÒade espacio entre paneles; `border_thickness` envuelve el lienzo final.
-- **Ajustes de diagonales**: combina `first_division_angle` y `diagonal_slant_offset (second_division_angle)` para mover el punto de encuentro de las lÌneas. Valores positivos empujan hacia abajo/derecha, negativos hacia arriba/izquierda.
-- **Antialiasing**: los bordes se trazan en alta resoluciÛn y se reducen, evitando ìsierraî incluso con diagonales gruesas.
-- **Lectura oriental**: selecciona `right to left` para espejar toda la p·gina sin cambiar la cadena de layout.
-- **Relleno de im·genes**: conecta una lista de tensores (por ejemplo, con `LoadImage` + `ImageBatch`). El nodo recorta cada imagen al aspecto del panel antes de pegarla.
+- **Separaciones**: `internal_padding` a√±ade espacio entre paneles; `border_thickness` envuelve el lienzo final.
+- **Ajustes de diagonales**: combina `first_division_angle` y `diagonal_slant_offset (second_division_angle)` para mover el punto de encuentro de las l√≠neas. Valores positivos empujan hacia abajo/derecha, negativos hacia arriba/izquierda.
+- **Antialiasing**: los bordes se trazan en alta resoluci√≥n y se reducen, evitando ‚Äúsierra‚Äù incluso con diagonales gruesas.
+- **Lectura oriental**: selecciona `right to left` para espejar toda la p√°gina sin cambiar la cadena de layout.
+- **Relleno de im√°genes**: conecta una lista de tensores (por ejemplo, con `LoadImage` + `ImageBatch`). El nodo recorta cada imagen al aspecto del panel antes de pegarla.
 
 ## Salidas
-- **image**: p·gina final como tensor ComfyUI (RGB).
-- **show_help**: descripciÛn corta con recordatorios de comandos.
+- **image**: p√°gina final como tensor ComfyUI (RGB).
+- **show_help**: descripci√≥n corta con recordatorios de comandos.
 
 ## Roadmap
-- Herramientas opcionales para numeraciÛn de paneles y texto auxiliar.
-- Layouts compatibles con m·rgenes interiores asimÈtricos.
+- Herramientas opcionales para numeraci√≥n de paneles y texto auxiliar.
+- Layouts compatibles con m√°rgenes interiores asim√©tricos.
 - Exportadores directos a PDF/PNG en lote.
 
 ---


### PR DESCRIPTION
## Summary
- add a secondary division position input to CR_ComicPanelTemplates to shift internal splits in two-panel rows/columns
- adjust layout logic so H12/V12 inner dividers respond to the new slider while keeping diagonal offsets intact
- update help text and README to document the new control

## Testing
- python run_test.py *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68d8b498c038832ba939c6dc198a3dc9