### PR TITLE
Fix speech bubble overlay defaults

### DIFF
--- a/config/palette.py
+++ b/config/palette.py
@@ -29,7 +29,6 @@ color_mapping = {
     "lavender": (230, 230, 250),
     "violet": (238, 130, 238),
     "coral": (255, 127, 80),
-    "indigo": (75, 0, 130),
 }
 
 COLORS = [
@@ -62,5 +61,4 @@ COLORS = [
     "lavender",
     "violet",
     "coral",
-    "indigo",
 ]


### PR DESCRIPTION
## Summary
- make speech bubble text offsets optional and provide safe fallbacks for missing inputs
- ensure color selections default to expected black/white values and ignore the custom placeholder
- trim the color palette list to remove the unused trailing entry

## Testing
- python -m py_compile manga_speech_bubbles.py

------
https://chatgpt.com/codex/tasks/task_e_68db3294c774832ba81d53527cc73a28