### PR TITLE
Improve pointer attachment handling in speech bubble

### DIFF
--- a/manga_speech_bubbles.py
+++ b/manga_speech_bubbles.py
@@ -169,6 +169,141 @@ def _point_at_angle_on_rounded_rect(center_x, center_y, half_width, half_height,
     return center_x + dx * t_hit, center_y + dy * t_hit
 
 
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def _compute_pointer_base_points(
+    base_x: float,
+    base_y: float,
+    tangent_x: float,
+    tangent_y: float,
+    bubble_x0: float,
+    bubble_y0: float,
+    bubble_x1: float,
+    bubble_y1: float,
+    corner_radius: float,
+    pointer_base_width: float,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Project pointer base points so they stay on the rounded-rectangle outline."""
+
+    tolerance = 1e-4
+    on_left = abs(base_x - bubble_x0) <= tolerance
+    on_right = abs(base_x - bubble_x1) <= tolerance
+    on_top = abs(base_y - bubble_y0) <= tolerance
+    on_bottom = abs(base_y - bubble_y1) <= tolerance
+
+    def _assign_orientation(candidate_a, candidate_b):
+        dot_a = (candidate_a[0] - base_x) * tangent_x + (candidate_a[1] - base_y) * tangent_y
+        dot_b = (candidate_b[0] - base_x) * tangent_x + (candidate_b[1] - base_y) * tangent_y
+
+        if dot_a >= dot_b:
+            left, right = candidate_a, candidate_b
+            left_dot = dot_a
+        else:
+            left, right = candidate_b, candidate_a
+            left_dot = dot_b
+
+        if left_dot < 0:
+            left, right = right, left
+        return left, right
+
+    def _edge_span(minimum: float, maximum: float) -> float:
+        return max(0.0, maximum - minimum)
+
+    half_span = pointer_base_width / 2.0
+
+    if (on_left or on_right) and not (on_top or on_bottom):
+        edge_x = bubble_x0 if on_left else bubble_x1
+        min_y = bubble_y0 + corner_radius
+        max_y = bubble_y1 - corner_radius
+        span = _edge_span(min_y, max_y)
+        if span <= 1e-6:
+            candidate = (edge_x, _clamp(base_y, bubble_y0, bubble_y1))
+            return candidate, candidate
+
+        half_span = min(half_span, span / 2.0)
+        center_y = _clamp(base_y, min_y + half_span, max_y - half_span)
+        candidate_high = (edge_x, center_y + half_span)
+        candidate_low = (edge_x, center_y - half_span)
+        return _assign_orientation(candidate_high, candidate_low)
+
+    if (on_top or on_bottom) and not (on_left or on_right):
+        edge_y = bubble_y0 if on_top else bubble_y1
+        min_x = bubble_x0 + corner_radius
+        max_x = bubble_x1 - corner_radius
+        span = _edge_span(min_x, max_x)
+        if span <= 1e-6:
+            candidate = (_clamp(base_x, bubble_x0, bubble_x1), edge_y)
+            return candidate, candidate
+
+        half_span = min(half_span, span / 2.0)
+        center_x = _clamp(base_x, min_x + half_span, max_x - half_span)
+        candidate_right = (center_x + half_span, edge_y)
+        candidate_left = (center_x - half_span, edge_y)
+        return _assign_orientation(candidate_right, candidate_left)
+    if corner_radius > 0 and (on_left or on_right) and (on_top or on_bottom):
+        corner_center_x = bubble_x0 + corner_radius if on_left else bubble_x1 - corner_radius
+        corner_center_y = bubble_y0 + corner_radius if on_top else bubble_y1 - corner_radius
+
+        base_angle = math.atan2(base_y - corner_center_y, base_x - corner_center_x)
+
+        if on_top and on_left:
+            angle_start, angle_end = math.radians(180), math.radians(270)
+        elif on_top and on_right:
+            angle_start, angle_end = math.radians(270), math.radians(360)
+        elif on_bottom and on_right:
+            angle_start, angle_end = 0.0, math.radians(90)
+        else:
+            angle_start, angle_end = math.radians(90), math.radians(180)
+
+        max_delta = (angle_end - angle_start) / 2.0
+        delta = min(half_span / corner_radius, max_delta)
+
+        candidate_a_angle = _clamp(base_angle + delta, angle_start, angle_end)
+        candidate_b_angle = _clamp(base_angle - delta, angle_start, angle_end)
+
+        candidate_a = (
+            corner_center_x + corner_radius * math.cos(candidate_a_angle),
+            corner_center_y + corner_radius * math.sin(candidate_a_angle),
+        )
+        candidate_b = (
+            corner_center_x + corner_radius * math.cos(candidate_b_angle),
+            corner_center_y + corner_radius * math.sin(candidate_b_angle),
+        )
+        return _assign_orientation(candidate_a, candidate_b)
+
+    if abs(tangent_y) >= abs(tangent_x):
+        edge_x = bubble_x0 if on_left else bubble_x1
+        min_y = bubble_y0 + corner_radius
+        max_y = bubble_y1 - corner_radius
+        span = _edge_span(min_y, max_y)
+        if span <= 1e-6:
+            candidate = (edge_x, _clamp(base_y, bubble_y0, bubble_y1))
+            return candidate, candidate
+
+        half_span = min(half_span, span / 2.0)
+        center_y = _clamp(base_y, min_y + half_span, max_y - half_span)
+        candidate_high = (edge_x, center_y + half_span)
+        candidate_low = (edge_x, center_y - half_span)
+        return _assign_orientation(candidate_high, candidate_low)
+
+    edge_y = bubble_y0 if on_top else bubble_y1
+    min_x = bubble_x0 + corner_radius
+    max_x = bubble_x1 - corner_radius
+    span = _edge_span(min_x, max_x)
+    if span <= 1e-6:
+        candidate = (_clamp(base_x, bubble_x0, bubble_x1), edge_y)
+        return candidate, candidate
+
+    half_span = min(half_span, span / 2.0)
+    center_x = _clamp(base_x, min_x + half_span, max_x - half_span)
+    candidate_right = (center_x + half_span, edge_y)
+    candidate_left = (center_x - half_span, edge_y)
+    return _assign_orientation(candidate_right, candidate_left)
+
+
+
 def _generate_rounded_rect_points(x0, y0, x1, y1, radius, exclude_start_angle=None, exclude_end_angle=None, segments_per_corner=12):
     """Generate points for rounded rectangle, optionally excluding an angular range."""
     points = []
@@ -264,15 +399,24 @@ def _create_bubble_with_pointer(
     
     # Pointer base width
     pointer_base_width = min(max(pointer_length * 0.35, 18.0), 70.0)
-    half_base = pointer_base_width / 2
-    
+
     # Tangent (perpendicular to direction)
     tangent_x = -direction_y
     tangent_y = direction_x
-    
+
     # Three pointer points
-    base_left = (base_x + tangent_x * half_base, base_y + tangent_y * half_base)
-    base_right = (base_x - tangent_x * half_base, base_y - tangent_y * half_base)
+    base_left, base_right = _compute_pointer_base_points(
+        base_x,
+        base_y,
+        tangent_x,
+        tangent_y,
+        bubble_x0,
+        bubble_y0,
+        bubble_x1,
+        bubble_y1,
+        clamped_radius,
+        pointer_base_width,
+    )
     tip = (base_x + direction_x * pointer_length, base_y + direction_y * pointer_length)
     
     # Calculate angles of base points
@@ -297,7 +441,31 @@ def _create_bubble_with_pointer(
         exclude_end,
         segments_per_corner=15
     )
-    
+
+    bubble_point_angles = [
+        math.degrees(math.atan2(py - center_y, px - center_x)) % 360
+        for px, py in bubble_points
+    ]
+
+    gap_index = 0
+    largest_gap = -1.0
+    pointer_gap = -1.0
+    pointer_gap_index = -1
+    for idx in range(len(bubble_points)):
+        current_angle = bubble_point_angles[idx]
+        next_angle = bubble_point_angles[(idx + 1) % len(bubble_points)]
+        gap = (next_angle - current_angle) % 360.0
+        if gap > largest_gap:
+            largest_gap = gap
+            gap_index = idx
+        if ((pointer_angle_norm - current_angle) % 360.0) < gap:
+            if gap > pointer_gap:
+                pointer_gap = gap
+                pointer_gap_index = idx
+
+    if pointer_gap_index >= 0:
+        gap_index = pointer_gap_index
+
     if not bubble_points:
         # Fallback
         draw.rounded_rectangle(
@@ -314,41 +482,34 @@ def _create_bubble_with_pointer(
     # margin removes most of the neighbouring outline points), we compare the
     # travel distance along the outline between the two nearest locations.
 
-    def _nearest_index(point):
-        closest_index = 0
-        closest_dist = float("inf")
-        for idx, candidate in enumerate(bubble_points):
-            dist = math.hypot(candidate[0] - point[0], candidate[1] - point[1])
-            if dist < closest_dist:
-                closest_dist = dist
-                closest_index = idx
-        return closest_index
+    def _option_cost(index: int, first_point, last_point) -> float:
+        """Calculate how well the pointer sequence blends with the outline."""
 
-    idx_left = _nearest_index(base_left)
-    idx_right = _nearest_index(base_right)
-
-    angle_diff = (angle_right - angle_left) % 360
-
-    if idx_left == idx_right:
-        # When both bases map to the same outline vertex (can happen with small
-        # exclusion margins), fall back to angular ordering.
-        if angle_diff < 180:
-            insert_idx = idx_left
-            insert_sequence = [base_left, tip, base_right]
+        prev_point = bubble_points[index]
+        if index + 1 < len(bubble_points):
+            next_point = bubble_points[index + 1]
         else:
-            insert_idx = idx_right
-            insert_sequence = [base_right, tip, base_left]
-    else:
-        total_points = len(bubble_points)
-        forward_distance = (idx_right - idx_left) % total_points
-        backward_distance = (idx_left - idx_right) % total_points
+            next_point = bubble_points[0]
 
-        if forward_distance != 0 and (forward_distance < backward_distance or backward_distance == 0):
-            insert_idx = idx_left
-            insert_sequence = [base_left, tip, base_right]
-        else:
-            insert_idx = idx_right
-            insert_sequence = [base_right, tip, base_left]
+        return math.hypot(prev_point[0] - first_point[0], prev_point[1] - first_point[1]) + math.hypot(
+            last_point[0] - next_point[0], last_point[1] - next_point[1]
+        )
+
+    options = [
+        (gap_index, [base_left, tip, base_right]),
+        (gap_index, [base_right, tip, base_left]),
+    ]
+
+    best_cost = float("inf")
+    insert_idx = 0
+    insert_sequence: list[tuple[float, float]] = []
+
+    for index, sequence in options:
+        cost = _option_cost(index, sequence[0], sequence[-1])
+        if cost < best_cost:
+            best_cost = cost
+            insert_idx = index
+            insert_sequence = sequence
 
     final_points = (
         bubble_points[:insert_idx + 1]


### PR DESCRIPTION
## Summary
- add geometry-aware helper to keep pointer base points constrained to the rounded rectangle outline
- choose pointer insertion region based on the angular gap that contains the pointer direction and pick the best orientation by minimising seam distance

## Testing
- python -m py_compile manga_speech_bubbles.py

------
https://chatgpt.com/codex/tasks/task_e_68db4eb89dd0832b887f6bd26942c87c