### PR TITLE
Update README to document speech bubble nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ MangaPanelizer es un paquete de nodos personalizados para ComfyUI enfocado en di
 2. Clona el repositorio o copia esta carpeta: `git clone https://github.com/your-user/MangaPanelizer.git`.
 3. Reinicia ComfyUI. Encontrarás el nodo bajo **MangaPanelizer / Templates**.
 
-## Nodo disponible
+## Nodos disponibles
 ### CR_ComicPanelTemplates
 Genera una página completa y devuelve:
 - `image`: tensor de imagen listo para ComfyUI.
@@ -38,6 +38,14 @@ Genera una página completa y devuelve:
 
 #### Entradas opcionales
 - `images`: lote de tensores. Cada panel recibe la siguiente imagen disponible; si faltan, se rellenan con el color del panel.
+
+### Manga Speech Bubble Overlay
+Colección de nodos para crear globos de diálogo y superponerlos sobre tus páginas:
+- **MangaSpeechBubbleBase**: prepara la capa del globo con bordes suavizados y punta ajustable.
+- **MangaSpeechBubbleText**: compone el texto con fuentes incluidas y espaciado configurable.
+- **MangaSpeechBubbleComposite**: combina base y texto en una sola imagen.
+- **MangaSpeechBubbleOverlay**: integra el globo final sobre tu página o panel.
+Todos comparten la misma paleta `COLORS` y admiten ajustes de posición, rotación y colores personalizables.
 
 ## Plantillas incluidas
 ```


### PR DESCRIPTION
## Summary
- document the Manga Speech Bubble node family in the README
- highlight the base, text, composite, and overlay components and their shared controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e175e68ce4832bbc04916a78256fd7